### PR TITLE
(test) Adds unit tests for HTTP requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Build better habits",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node server/server.js & mocha test/ServerSpec.js; RES=$?; kill %1; exit $RES",
     "start": "nodemon server/server.js"
   },
   "repository": {
@@ -20,10 +20,12 @@
   "dependencies": {
     "bluebird": "^3.3.4",
     "body-parser": "^1.15.0",
+    "chai": "^3.5.0",
     "express": "^4.13.4",
     "mocha": "^2.4.5",
     "mongoose": "^4.4.6",
     "morgan": "^1.7.0",
-    "nodemon": "^1.9.1"
+    "nodemon": "^1.9.1",
+    "request": "^2.69.0"
   }
 }

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -3,7 +3,6 @@ var Instance = require('../db/models').Instance;
 var Instances = require('../db/models').Instances;
 var User = require('../db/models').User;
 
-
 var getHabits = function (success, fail) {
   Habit.find({})
     .then(function (data) {
@@ -18,7 +17,7 @@ var addHabit = function (habit, success, fail) {
   Habit.create(habit)
     .then(function (data) {
       var instances = new Instances;
-      data.instancesId = instances.id
+      data.instancesId = instances.id;
       instances.save();
       data.save();
       success(data);
@@ -46,13 +45,13 @@ var updateHabit = function (habitid, habitDetails, success, fail) {
     .catch(function (err) {
       console.error(err);
       fail(err);
-    })
+    });
 };
 
 var createInstance = function (habitid, success, fail) {
   Habit.findById(habitid)
     .then(function (habit) {
-      return Instances.findById(habit.instancesId)
+      return Instances.findById(habit.instancesId);
     })
     .then(function (instances) {
       var instance = new Instance;
@@ -64,8 +63,9 @@ var createInstance = function (habitid, success, fail) {
     .catch(function (err) {
       console.error(err);
       fail(err);
-    })
-}
+    });
+};
+
 module.exports = {
   updateHabit: updateHabit,
   addHabit: addHabit,

--- a/server/routes.js
+++ b/server/routes.js
@@ -35,7 +35,7 @@ var routes = [{
       },
       function (err) {
         console.error(err);
-        res.status(400)
+        res.status(400);
       });
   },
   put: function (req, res) {
@@ -50,17 +50,17 @@ var routes = [{
       });
   },
   delete: function (req, res) {
-    helpers.deleteHabit(req.params.habitid, function (err) {
+    var habitid = req.params.habitid;
+    helpers.deleteHabit(habitid, function (data) {
+      res.status(202).send(data);
+    }, function (err) {
       console.error('Server error: ', err);
       res.sendStatus(500);
-    }, function () {
-      res.send('Habit removed.');
     });
   }
 }];
 
 module.exports = function (app, express) {
-
   routes.forEach(function (route) {
     for (var key in route) {
       if (key === 'path') {

--- a/test/ServerSpec.js
+++ b/test/ServerSpec.js
@@ -1,0 +1,104 @@
+// Test modules
+var request = require('request');
+var expect = require('chai').expect;
+
+// DB connection
+var db = require('../db/db');
+
+// DB Models
+var Habit = require('../db/models').Habit;
+var Instance = require('../db/models').Instance;
+var Instances = require('../db/models').Instances;
+var User = require('../db/models').User;
+
+describe('Basic Server', function () {
+  // To store ID from POST response to use in PUT/DELETE tests
+  var habitid;
+
+  describe('GET /habits', function () {
+    it('should return status code 200', function (done) {
+      request('http://localhost:3000/habits', function (err, res) {
+        if (err) {
+          console.error(err);
+        }
+        expect(res.statusCode).to.equal(200);
+        done();
+      });
+    });
+  });
+
+  describe('POST /habits', function () {
+    afterEach(function (done) {
+      Habit.remove({})
+        .then(function (success) {
+          // console.log('Habits successfully removed');
+        })
+        .catch(function (err) {
+          console.error(err);
+        });
+
+      done();
+    });
+
+    it('should return status code 201', function (done) {
+      var reqParams = {
+        method: 'POST',
+        uri: 'http://localhost:3000/habits',
+        json: {
+          action: "floss",
+          frequency: "every night",
+          unit: "one tooth",
+          schedule: "9 PM"
+        }
+      };
+
+      request(reqParams, function (err, res) {
+        if (err) {
+          console.error(err);
+        }
+
+        // Storing ID to be used in PUT/DELETE requests
+        habitid = res.body._id;
+        expect(res.statusCode).to.equal(201);
+        done();
+      });
+    });
+  });
+
+  describe('PUT /habits/:habitid', function () {
+    it('should return status code 200', function (done) {
+      var reqParams = {
+        method: 'PUT',
+        uri: 'http://localhost:3000/habits/' + habitid,
+        json: {
+          schedule: '8 PM'
+        }
+      };
+
+      request(reqParams, function (err, res) {
+        if (err) {
+          console.error(err);
+        }
+        expect(res.statusCode).to.equal(200);
+        done();
+      });
+    });
+  });
+
+  describe ('DELETE /habits:habitid', function () {
+    it('should return status code 202', function (done) {
+      var reqParams = {
+        method: 'DELETE',
+        uri: 'http://localhost:3000/habits/' + habitid
+      };
+
+      request(reqParams, function (err, res) {
+        if (err) {
+          console.error(err);
+        }
+        expect(res.statusCode).to.equal(202);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Adds `chai`, `request`, and `npm test` script to `package.json`
 - Server doesn't need to be connected for tests to run but `mongod` does
-  Corrects some syntax/style inconsistencies
- Adds status code tests for:
 - `GET /habits`
 - `POST /habits`
 - `PUT /habits/:habitid`
 - `DELETE /habits/:habitid`