### PR TITLE
Refactors helpers, models, and DbSpec

### DIFF
--- a/db/models.js
+++ b/db/models.js
@@ -1,13 +1,17 @@
 var mongoose = require('mongoose');
 
+// Instance
 var instanceSchema = mongoose.Schema({}, { timestamps: true });
 
+
+// Instance store
 var instancesSchema = mongoose.Schema({
   store: [instanceSchema]
 });
-
 var Instances = mongoose.model('Instances', instancesSchema);
 
+
+// Habits
 var habitSchema = mongoose.Schema({
   action: { type: String, required: true }, // name of the activity habit
   frequency: { type: String, required: true }, // how often user wants to do the action (year, month, week, day, hour)
@@ -20,25 +24,43 @@ var habitSchema = mongoose.Schema({
 {
   timestamps: true
 });
+var Habit = mongoose.model('Habit', habitSchema);
 
+
+// Users
 var userSchema = mongoose.Schema({
-  username: { type: String, required: true },
+  email: { type: String, required: true, unique: true },
   fullName: { type: String },
   habits: [habitSchema]
 },
 {
   timestamps: true
 });
-
-var Habit = mongoose.model('Habit', habitSchema);
 var User = mongoose.model('User', userSchema);
+
+
+// Middleware
+habitSchema.post('remove', function (doc) {
+  var instanceId = doc.instancesId;
+  Instances.findByIdAndRemove(instanceId)
+    .then(function (success) {
+      // console.log('Post habit instance deletion success:', success);
+    })
+    .catch(function (err) {
+      console.error(err);
+    });
+});
 
 instancesSchema.post('save', function (doc) {
   Habit.findOneAndUpdate({ instancesId: doc._id }, { instanceCount: doc.store.length })
     .then(function (success) {
-      // console.log('Success:', success);
+      // console.log('Post instance creation habit update success:', success);
+    })
+    .catch(function (err) {
+      console.error(err);
     });
 });
+
 
 module.exports = {
   Habit: Habit,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "Build better habits",
   "main": "server.js",
   "scripts": {
-    "test": "mocha --require setup.js --compilers js:babel-core/register --recursive test/*.js",
+    "pretest": "mocha test/ServerSpec.js; mocha test/DbSpec.js",
+    "test": "mocha --require setup.js --compilers js:babel-core/register test/ClientSpec.js",
     "start": "node server/server.js",
     "local": "nodemon server/server.js"
   },

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -12,6 +12,15 @@ var getHabits = function (success, fail) {
       fail(err);
     });
 };
+// var getHabits = function (email, success, fail) {
+//   User.find({ email: email })
+//     .then(function (user) {
+//       success(user.habits);
+//     })
+//     .catch(function (err) {
+//       fail(err);
+//     });
+// };
 
 var addHabit = function (habit, success, fail) {
   if (habit.currentGoal) {
@@ -29,28 +38,44 @@ var addHabit = function (habit, success, fail) {
       fail(err);
     });
 };
+// var addHabit = function (email, habit, success, fail) {
+//   if (habit.currentGoal) {
+//     habit.currentGoal = parseInt(habit.currentGoal);
+//   }
+//   Habit.create(habit)
+//     .then(function (data) {
+//       return User.findOneAndUpdate(
+//         { email: email }, { $push: { "habits": data }}
+//       );
+//     })
+//     .then(function (data2) {
+//       success(data2);
+//     })
+//     .catch(function (err) {
+//       fail(err);
+//     });
+// };
 
 var deleteHabit = function (id, success, fail) {
-  var instanceId;
   Habit.findByIdAndRemove(id)
     .then(function (data) {
-      instanceId = data.instancesId;
-      return Instances.findByIdAndRemove(instanceId);
-    })
-    .then(function (deletedInstance) {
-
-      // deletedIds obj allows for both the deleted habit ID
-      // as well as the deleted instance ID to be sent back
-      var deletedIds = {
-        habitId: id,
-        instanceId: deletedInstance._id
-      };
-      success(deletedIds);
+      success(data);
     })
     .catch(function (err) {
       fail(err);
     });
 };
+// var deleteHabit = function (email, habitId, success, fail) {
+//   User.findOneAndUpdate(
+//     { email: email }, { $pull: { habits: { _id: habitId } }}
+//   )
+//   .then(function (data) {
+//     success(data);
+//   })
+//   .catch(function (err) {
+//     fail(err);
+//   });
+// };
 
 var updateHabit = function (habitid, habitDetails, success, fail) {
   if (habitDetails.currentGoal) {
@@ -64,6 +89,27 @@ var updateHabit = function (habitid, habitDetails, success, fail) {
       fail(err);
     });
 };
+// var updateHabit = function (email, habitid, habitDetails, success, fail) {
+//   if (habitDetails.currentGoal) {
+//     habitDetails.currentGoal = parseInt(habitDetails.currentGoal);
+//   }
+//
+//   // TODO: try 'habits.$' if 'habits.$.' doesn't work
+//   // Updates object allows for partial updates
+//   var updates = {};
+//   for (var key in habitDetails) {
+//     updates['habits.$.' + key] = habitDetails[key];
+//   }
+//   User.findOneAndUpdate(
+//     { email: email, habits._id: habitid }, { $set: updates }
+//   )
+//   .then(function (data) {
+//     success(data);
+//   })
+//   .catch(function (err) {
+//     fail(err);
+//   });
+// };
 
 var createInstance = function (habitid, success, fail) {
   Habit.findById(habitid)
@@ -100,11 +146,22 @@ var isDone = function (habitid, success, fail) {
     });
 };
 
+var addUser = function (email, success, fail) {
+  User.create(email)
+    .then(function (data) {
+      success(data);
+    })
+    .catch(function (err) {
+      fail(err);
+    });
+};
+
 module.exports = {
   updateHabit: updateHabit,
   addHabit: addHabit,
   deleteHabit: deleteHabit,
   getHabits: getHabits,
   createInstance: createInstance,
-  isDone: isDone
+  isDone: isDone,
+  addUser: addUser
 };

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -57,7 +57,13 @@ var addHabit = function (habit, success, fail) {
 // };
 
 var deleteHabit = function (id, success, fail) {
-  Habit.findByIdAndRemove(id)
+  Habit.find({ _id: id })
+    .then(function (data) {
+
+      // Mongoose post 'remove' middleware will
+      // not trigger on remove() calls to Habit model
+      return data[0].remove();
+    })
     .then(function (data) {
       success(data);
     })
@@ -67,7 +73,8 @@ var deleteHabit = function (id, success, fail) {
 };
 // var deleteHabit = function (email, habitId, success, fail) {
 //   User.findOneAndUpdate(
-//     { email: email }, { $pull: { habits: { _id: habitId } }}
+//   TODO: test if $pull triggers post 'remove' middleware
+//     { email: email }, { $pull: { habits._id: habitId } }
 //   )
 //   .then(function (data) {
 //     success(data);
@@ -95,7 +102,7 @@ var updateHabit = function (habitid, habitDetails, success, fail) {
 //   }
 //
 //   // TODO: try 'habits.$' if 'habits.$.' doesn't work
-//   // Updates object allows for partial updates
+//   // updates object allows for partial updates
 //   var updates = {};
 //   for (var key in habitDetails) {
 //     updates['habits.$.' + key] = habitDetails[key];
@@ -146,6 +153,7 @@ var isDone = function (habitid, success, fail) {
     });
 };
 
+// TODO: modify as needed once user info is available
 var addUser = function (email, success, fail) {
   User.create(email)
     .then(function (data) {

--- a/server/routes.js
+++ b/server/routes.js
@@ -3,94 +3,96 @@ var helpers = require('./helpers');
 // For suppressing (purposeful) error logging in tests
 var testing = process.env.NODE_ENV === 'test';
 
-var routes = [{
-  path: '/habits',
-  get: function (req, res) {
-    // query db for user's habits
-    helpers.getHabits(
-      function (success) {
-        res.json(success);
-      },
-      function (err) {
-        if (!testing) {
-          console.error('Server error:', err);
-        }
-        res.sendStatus(400);
-      });
-  },
-  post: function (req, res) {
-    var habit = req.body;
-    helpers.addHabit(habit,
-      function (data) {
-        res.status(201).send(data);
-      },
-      function (err) {
-        if (!testing) {
-          console.error('Server error:', err);
-        }
-        res.sendStatus(400);
-      });
-  }
-},
-{
-  path: '/habits/:habitid',
-  post: function (req, res) {
-    var habitid = req.params.habitid;
-    helpers.createInstance(habitid,
-      function (data) {
-        res.status(201).send(data);
-      },
-      function (err) {
-        if (!testing) {
-          console.error('Server error:', err);
-        }
-        res.status(400);
-      });
-  },
-  put: function (req, res) {
-    var habitid = req.params.habitid;
-    var habitDetails = req.body;
-    helpers.updateHabit(habitid, habitDetails,
-      function (data) {
-        res.status(200).send(data);
-      },
-      function (err) {
-        if (!testing) {
-          console.error('Server error:', err);
-        }
-        res.sendStatus(400);
-      });
-  },
-  delete: function (req, res) {
-    var habitid = req.params.habitid;
-    helpers.deleteHabit(habitid,
-    function (data) {
-      res.status(202).send(data);
+var routes = [
+  {
+    path: '/habits',
+    get: function (req, res) {
+      // query db for user's habits
+      helpers.getHabits(
+        function (success) {
+          res.json(success);
+        },
+        function (err) {
+          if (!testing) {
+            console.error('Server error:', err);
+          }
+          res.sendStatus(400);
+        });
     },
-    function (err) {
-      if (!testing) {
-        console.error('Server error:', err);
-      }
-      res.sendStatus(500);
-    });
-  }
-},
-{
-  path: '/done/:habitid',
-  get: function (req, res) {
-    var habitid = req.params.habitid;
-    helpers.isDone(habitid,
-    function (done) {
-      res.send(done);
+    post: function (req, res) {
+      var habit = req.body;
+      helpers.addHabit(habit,
+        function (data) {
+          res.status(201).send(data);
+        },
+        function (err) {
+          if (!testing) {
+            console.error('Server error:', err);
+          }
+          res.sendStatus(400);
+        });
+    }
+  },
+  {
+    path: '/habits/:habitid',
+    post: function (req, res) {
+      var habitid = req.params.habitid;
+      helpers.createInstance(habitid,
+        function (data) {
+          res.status(201).send(data);
+        },
+        function (err) {
+          if (!testing) {
+            console.error('Server error:', err);
+          }
+          res.status(400);
+        });
     },
-    function (err) {
-      if (!testing) {
-        console.error('Server error:', err);
-      }
-      res.sendStatus(500);
-    });
+    put: function (req, res) {
+      var habitid = req.params.habitid;
+      var habitDetails = req.body;
+      helpers.updateHabit(habitid, habitDetails,
+        function (data) {
+          res.status(200).send(data);
+        },
+        function (err) {
+          if (!testing) {
+            console.error('Server error:', err);
+          }
+          res.sendStatus(400);
+        });
+    },
+    delete: function (req, res) {
+      var habitid = req.params.habitid;
+      helpers.deleteHabit(habitid,
+        function (data) {
+          res.status(202).send(data);
+        },
+        function (err) {
+          if (!testing) {
+            console.error('Server error:', err);
+          }
+          res.sendStatus(500);
+        });
+    }
+  },
+  {
+    path: '/done/:habitid',
+    get: function (req, res) {
+      var habitid = req.params.habitid;
+      helpers.isDone(habitid,
+        function (done) {
+          res.send(done);
+        },
+        function (err) {
+          if (!testing) {
+            console.error('Server error:', err);
+          }
+          res.sendStatus(500);
+        });
+    }
   }
-}];
+];
 
 module.exports = function (app, express) {
   routes.forEach(function (route) {

--- a/test/DbSpec.js
+++ b/test/DbSpec.js
@@ -150,16 +150,24 @@ describe('Database', function () {
         done();
       });
 
+      // TODO: refactor after updated deleteHabit helper is implemented
+      // success data will be modified
       it('should delete habit and corresponding instance store', function (done) {
         helpers.deleteHabit(habit1Id,
           function (success) {
-            expect(success.habitId.toString()).to.equal(habit1Id);
+            expect(success._id.toString()).to.equal(habit1Id);
 
             // In order to confirm instance was deleted,
             // instance1Id is assigned in beforeEach function
-            // on line 50 when habit1 is successfully created
-            expect(success.instanceId.toString()).to.equal(instance1Id);
-            done();
+            // on line 49 when habit1 is successfully created
+            Instances.findById(instance1Id)
+              .then(function (success) {
+                expect(success).to.equal(null);
+                done();
+              })
+              .catch(function (err) {
+                console.error('Instance fail:', err);
+              });
           },
           function (fail) {
             console.error('DbSpec deleteHabit error:', fail);

--- a/test/ServerSpec.js
+++ b/test/ServerSpec.js
@@ -227,7 +227,7 @@ describe('Basic Server', function () {
         .delete('/habits/' + habit1Id)
         .expect(202)
         .expect(function (res) {
-          expect(habit1Id).to.equal(res.body.habitId);
+          expect(habit1Id).to.equal(res.body._id);
         })
         .end(done);
     });


### PR DESCRIPTION
- Refactors/rearranges schemas and model declarations in `models.js`
 - Adds `habitSchema` middleware to auto delete instance store upon habit deletion
 - Renames 'user' field in `userSchema` to 'email'
   - Adds 'unique' requirement
 - Refactors `deleteHabit` helper to properly trigger Mongoose middleware
   - Refactors test to reflect changes
- Adds `pretest` script to `package.json` to run back end tests before front end. Running all tests in a single command prevented `ServerSpec.js` from executing properly
- Helpers
 - Adds refactored and commented functions for when users are fully implemented
 - Adds `addUser` function to store user information
- Closes #81 