### PR TITLE
Refactors helpers and DbSpec tests

### DIFF
--- a/db/models.js
+++ b/db/models.js
@@ -50,6 +50,7 @@ habitSchema.post('remove', function (doc) {
     });
 });
 
+// TODO: convert to habit post save
 instancesSchema.post('save', function (doc) {
   if (doc.store.length) {
     Habit.findOneAndUpdate({ instancesId: doc._id }, { instanceCount: doc.store.length, lastDone: doc.store[doc.store.length - 1].createdAt })

--- a/db/models.js
+++ b/db/models.js
@@ -50,38 +50,21 @@ habitSchema.post('remove', function (doc) {
     });
 });
 
-// Before a habit is saved, an instance is
-// auto-created and its ID is assigned upon success
-habitSchema.pre('save', function (next) {
-
-  // 'this' references the habit being saved
-  var _this = this;
-  Instances.create({})
-    .then(function (success) {
-      _this.instancesId = success._id;
-
-      // Invoking next allows the habit to save
-      next();
-    })
-    .catch(function (err) {
-      console.error(err);
-    });
+instancesSchema.post('save', function (doc) {
+  if (doc.store.length) {
+    Habit.findOneAndUpdate({ instancesId: doc._id }, { instanceCount: doc.store.length, lastDone: doc.store[doc.store.length - 1].createdAt })
+      .then(function (success) {})
+      .catch(function (err) {
+        console.error(err);
+      });
+  } else {
+    Habit.findOneAndUpdate({ instancesId: doc._id }, { instanceCount: 0 })
+      .then(function (success) {})
+      .catch(function (err) {
+        console.error(err);
+      });
+  }
 });
-// instancesSchema.post('save', function (doc) {
-//   if (doc.store.length) {
-//     Habit.findOneAndUpdate({ instancesId: doc._id }, { instanceCount: doc.store.length, lastDone: doc.store[doc.store.length - 1].createdAt })
-//       .then(function (success) {})
-//       .catch(function (err) {
-//         console.error(err);
-//       });
-//   } else {
-//     Habit.findOneAndUpdate({ instancesId: doc._id }, { instanceCount: 0 })
-//       .then(function (success) {})
-//       .catch(function (err) {
-//         console.error(err);
-//       });
-//   }
-// });
 
 
 module.exports = {

--- a/db/models.js
+++ b/db/models.js
@@ -50,22 +50,38 @@ habitSchema.post('remove', function (doc) {
     });
 });
 
-// TODO: convert to habit post save
-instancesSchema.post('save', function (doc) {
-  if (doc.store.length) {
-    Habit.findOneAndUpdate({ instancesId: doc._id }, { instanceCount: doc.store.length, lastDone: doc.store[doc.store.length - 1].createdAt })
-      .then(function (success) {})
-      .catch(function (err) {
-        console.error(err);
-      });
-  } else {
-    Habit.findOneAndUpdate({ instancesId: doc._id }, { instanceCount: 0 })
-      .then(function (success) {})
-      .catch(function (err) {
-        console.error(err);
-      });
-  }
+// Before a habit is saved, an instance is
+// auto-created and its ID is assigned upon success
+habitSchema.pre('save', function (next) {
+
+  // 'this' references the habit being saved
+  var _this = this;
+  Instances.create({})
+    .then(function (success) {
+      _this.instancesId = success._id;
+
+      // Invoking next allows the habit to save
+      next();
+    })
+    .catch(function (err) {
+      console.error(err);
+    });
 });
+// instancesSchema.post('save', function (doc) {
+//   if (doc.store.length) {
+//     Habit.findOneAndUpdate({ instancesId: doc._id }, { instanceCount: doc.store.length, lastDone: doc.store[doc.store.length - 1].createdAt })
+//       .then(function (success) {})
+//       .catch(function (err) {
+//         console.error(err);
+//       });
+//   } else {
+//     Habit.findOneAndUpdate({ instancesId: doc._id }, { instanceCount: 0 })
+//       .then(function (success) {})
+//       .catch(function (err) {
+//         console.error(err);
+//       });
+//   }
+// });
 
 
 module.exports = {

--- a/index.ios.js
+++ b/index.ios.js
@@ -3,7 +3,7 @@ var React = require('react-native')
 var AppRegistry = React.AppRegistry;
 var AppContainer = require('./app/containers/AppContainer');
 
-var localServer = true;
+var localServer = false;
 
 if (localServer === true) {
   process.env.SERVER = 'http://localhost:3000'

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -43,8 +43,11 @@ var addHabit = function (email, habit, success, fail) {
   }
   Habit.create(habit)
     .then(function (data) {
+
+      // The {new: true} option returns the modified document
+      // rather than the original. defaults to false
       return User.findOneAndUpdate(
-        { email: email }, { $push: { "habits": data }}
+        { email: email }, { $push: { "habits": data } }, { new: true }
       );
     })
     .then(function (data2) {
@@ -73,7 +76,7 @@ var addHabit = function (email, habit, success, fail) {
 var deleteHabit = function (email, habitId, success, fail) {
   User.findOneAndUpdate(
   // TODO: test if $pull triggers post 'remove' middleware
-    {email: email}, {$pull: {'habits': {_id: habitId}}}
+    { email: email }, { $pull: { 'habits': { _id: habitId } }}
   )
   .then(function (data) {
     success(data);
@@ -153,10 +156,9 @@ var isDone = function (habitid, success, fail) {
 };
 
 var addUser = function (email, success, fail) {
-  console.log("ADDUSER EMAIL:", email);
   // findOneAndUpdate along with upsert set to true
   // allows for a user to be created if they don't exist
-  User.findOneAndUpdate({email: email}, { email: email }, {upsert: true})
+  User.findOneAndUpdate({ email: email }, { email: email }, {upsert: true})
     .then(function (data) {
       success(data);
     })

--- a/server/routes.js
+++ b/server/routes.js
@@ -125,10 +125,10 @@ var routes = [
 module.exports = function (app, express) {
   // require auth on all routes in authReqRoutes
   // skip if we are testing
-  if(!testing) {
+  if (!testing) {
     authReqRoutes.forEach(function (route) {
-      app.use(route, jwtCheck)
-    })
+      app.use(route, jwtCheck);
+    });
   }
 
   // export routes

--- a/server/routes.js
+++ b/server/routes.js
@@ -32,7 +32,6 @@ var routes = [
         });
     },
     post: function (req, res) {
-      console.log('POST to /user:', req.body);
       var userEmail = req.body.email;
       helpers.addUser(userEmail,
         function (success) {
@@ -49,13 +48,11 @@ var routes = [
   {
     path: '/habits/:user',
     get: function (req, res) {
-      console.log('USAH', req.params.user);
       var userEmail = req.params.user;
       // query db for user's habits
       helpers.getHabits(userEmail,
         function (success) {
-          console.log('/habits GET:', success);
-          res.json(success);
+          res.status(200).json(success);
         },
         function (err) {
           if (!testing) {
@@ -113,7 +110,7 @@ var routes = [
       var habitid = req.params.habitid;
       helpers.deleteHabit(userEmail, habitid,
         function (data) {
-          res.status(200).send(data);
+          res.status(200).json(data);
         },
         function (err) {
           if (!testing) {

--- a/test/DbSpec.js
+++ b/test/DbSpec.js
@@ -166,7 +166,7 @@ describe('Database', function () {
 
     });
 
-    xdescribe('deleteHabit', function () {
+    describe('deleteHabit', function () {
 
       it('should be a function', function (done) {
         expect(helpers.deleteHabit).to.be.a('function');
@@ -176,7 +176,7 @@ describe('Database', function () {
       // TODO: refactor after updated deleteHabit helper is implemented
       // success data will be modified
       it('should delete habit and corresponding instance store', function (done) {
-        helpers.deleteHabit(habit1Id,
+        helpers.deleteHabit(user.email, habit1Id,
           function (success) {
             expect(success._id.toString()).to.equal(habit1Id);
 
@@ -198,7 +198,7 @@ describe('Database', function () {
       });
 
       it('should error when attempting to delete invalid ID', function (done) {
-        helpers.deleteHabit('12345',
+        helpers.deleteHabit(user.email, '12345',
           function (success) {
             console.log('DbSpec deleteHabit success:', success);
           },

--- a/test/ServerSpec.js
+++ b/test/ServerSpec.js
@@ -13,6 +13,7 @@ var app = require('../server/server');
 
 // DB Models
 var mongoose = require('mongoose');
+var User = require('../db/models').User;
 var Habit = require('../db/models').Habit;
 var Instances = require('../db/models').Instances;
 


### PR DESCRIPTION
(In order of display)

1. `models.js`
 - Adds 'pre save' middleware to `habitSchema` to handle the creation of instances automatically instead of in `helpers.js`
   - `instanceSchema` middleware left commented out for reference
2. `helpers.js`
 - Minor spacing additions for formatting consistency
 - Line 50 adds a new option `{ new: true }` in order to send back modified data instead of original (defaults to false)
3. `routes.js`
 - Removes a few console.logs
 - Converts remaining `res.send`/`res.json` to `res.status(num).json(data)` to maintain consistency
4. `DbSpec.js`
 - Refactors `beforeEach`, `getHabits`, `addHabits`, and `deleteHabits` to reflect changes introduced by users
5. `ServerSpec.js`
 - Requires `User` model for future refactoring